### PR TITLE
Fix FTP TLS node implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node": "^24.0.12",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": "^8.29.0",
     "eslint-plugin-n8n-nodes-base": "^1.11.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
   },
   "include": [
     "credentials/**/*",
-    "nodes/**/*"
+    "nodes/**/*",
+    "types/**/*"
   ],
   "exclude": [
     "dist",

--- a/types/ssh2-sftp-client.d.ts
+++ b/types/ssh2-sftp-client.d.ts
@@ -1,0 +1,1 @@
+declare module 'ssh2-sftp-client';


### PR DESCRIPTION
## Summary
- fix imports and use NodeConnectionType
- adjust execute method and private methods
- add in-memory download support
- pass execution context to helper methods
- add missing @types/node and custom type for ssh2-sftp-client

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fc44c043c83318a5e59f61c7e0047